### PR TITLE
refactor: choose whether dest == exit when creating a connection

### DIFF
--- a/mix.nimble
+++ b/mix.nimble
@@ -6,7 +6,7 @@ license = "MIT"
 # Dependencies
 requires "stew >= 0.3.0"
 requires "chronos >= 4.0.3"
-requires "https://github.com/vacp2p/nim-libp2p#64c9cf1b9e69a6d1da9f430ffb1f91e949658f28"
+requires "https://github.com/vacp2p/nim-libp2p#f83638eb82f04bcdd2e98ef1bf8f52d9e13250c0"
 requires "nim >= 1.6.0"
 requires "nimcrypto >= 0.6.0"
 requires "serialization >= 0.2.2"

--- a/mix/examples/poc_gossipsub.nim
+++ b/mix/examples/poc_gossipsub.nim
@@ -132,7 +132,7 @@ proc mixnet_gossipsub_test() {.async: (raises: [Exception]).} =
             Opt.some(destAddr.unsafeGet())
           else:
             Opt.none(MultiAddress)
-        return mixProto.createMixEntryConnection(destOpt, destPeerId, codec)
+        return mixProto.toConnection(destOpt, destPeerId, codec)
       except CatchableError as e:
         error "Error during execution of MixEntryConnection callback: ", err = e.msg
         return nil

--- a/mix/examples/poc_gossipsub_repeated_runs.nim
+++ b/mix/examples/poc_gossipsub_repeated_runs.nim
@@ -136,7 +136,7 @@ proc mixnet_gossipsub_test(): Future[int] {.async: (raises: [Exception]).} =
             Opt.some(destAddr.unsafeGet())
           else:
             Opt.none(MultiAddress)
-        return mixProto.createMixEntryConnection(destOpt, destPeerId, codec)
+        return mixProto.toConnection(destOpt, destPeerId, codec)
       except CatchableError as e:
         error "Error during execution of MixEntryConnection callback: ", err = e.msg
         return nil

--- a/mix/examples/poc_noresp_ping.nim
+++ b/mix/examples/poc_noresp_ping.nim
@@ -106,11 +106,11 @@ proc mixnetSimulation() {.async: (raises: [Exception]).} =
   if senderIndex < numberOfNodes - 1:
     receiverIndex = senderIndex + 1
 
-  let conn = createMixEntryConnection(
-    mixProto[senderIndex],
+  let conn = mixProto[senderIndex].toConnection(
     Opt.some(nodes[receiverIndex].peerInfo.addrs[0]),
     nodes[receiverIndex].peerInfo.peerId,
     NoRespPingCodec,
+    true,
   )
 
   discard await noRespPingProto[senderIndex].noRespPing(conn)

--- a/mix/mix_protocol.nim
+++ b/mix/mix_protocol.nim
@@ -228,6 +228,7 @@ proc anonymizeLocalProtocolSend*(
     proto: ProtocolType,
     destMultiAddr: Opt[MultiAddress],
     destPeerId: PeerId,
+    exitNodeIsDestination: bool,
 ) {.async.} =
   let mixMsg = initMixMessage(msg, proto)
 
@@ -287,7 +288,7 @@ proc anonymizeLocalProtocolSend*(
 
   var i = 0
   while i < L:
-    if destIsExit(proto) and i == L - 1:
+    if exitNodeIsDestination and i == L - 1:
       randPeerId = destPeerId
     else:
       let randomIndexPosition = cryptoRandomInt(availableIndices.len).valueOr:
@@ -299,7 +300,7 @@ proc anonymizeLocalProtocolSend*(
       availableIndices.del(randomIndexPosition)
 
     # Skip the destination peer
-    if not destIsExit(proto) and randPeerId == destPeerId:
+    if not exitNodeIsDestination and randPeerId == destPeerId:
       continue
 
     info "Selected mix node: ", indexInPath = i, peerId = randPeerId
@@ -331,7 +332,7 @@ proc anonymizeLocalProtocolSend*(
     return
 
   var destHop = Opt.none(Hop)
-  if not destIsExit(proto):
+  if not exitNodeIsDestination:
     #Encode destination
     let dest = $destMultiAddr & "/p2p/" & $destPeerId
     let destAddrBytes = multiAddrToBytes(dest).valueOr:


### PR DESCRIPTION
Small refactor to how mix connections are created. 
Consumers of the mix can do:
```nim
mixProto.toConnection(destOpt, destPeerId, codec, destIsExit)
```
To receive a `Connection`. Last parameter is optional, with default `false`