### PR TITLE
refactor: make mix protocol agnostic

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,7 +11,7 @@ jobs:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
       test-command: |
-       nimble c ./mix/examples/poc_gossipsub.nim
-       nimble c ./mix/examples/poc_gossipsub_repeated_runs.nim
-       nimble c ./mix/examples/poc_noresp_ping.nim
+       nimble c ./examples/poc_gossipsub.nim
+       nimble c ./examples/poc_gossipsub_repeated_runs.nim
+       nimble c ./examples/poc_noresp_ping.nim
       nim-versions: '["version-2-0", "version-2-2", "devel"]'

--- a/mix.nim
+++ b/mix.nim
@@ -15,5 +15,6 @@ export writeMixNodeInfoToFile
 export mixNodes
 export getMixNodeInfo
 export `new`
+export getMaxMessageSizeForCodec
 export deleteNodeInfoFolder
 export deletePubInfoFolder

--- a/mix/entry_connection_callbacks.nim
+++ b/mix/entry_connection_callbacks.nim
@@ -3,7 +3,7 @@
 import chronos, chronicles, results
 import std/[sequtils, sets]
 import libp2p/[multiaddress, protocols/pubsub/pubsubpeer, switch]
-import ./[entry_connection, mix_protocol, protocol]
+import ./[entry_connection, mix_protocol]
 
 const D* = 4 # No. of peers to forward to
 

--- a/mix/mix_message.nim
+++ b/mix/mix_message.nim
@@ -1,69 +1,85 @@
 import chronicles, results
-import ./[config, protocol, utils]
+import ./[config, utils]
+import stew/[byteutils, leb128]
+import libp2p/protobuf/minprotobuf
 
 type MixMessage* = object
-  message: seq[byte]
-  protocol: ProtocolType
+  message*: seq[byte]
+  codec*: string
 
-proc initMixMessage*(message: openArray[byte], protocol: ProtocolType): MixMessage =
-  return MixMessage(message: @message, protocol: protocol)
+proc new*(T: typedesc[MixMessage], message: openArray[byte], codec: string): T =
+  return T(message: @message, codec: codec)
 
-proc getMixMessage*(mixMsg: MixMessage): (seq[byte], ProtocolType) =
-  return (mixMsg.message, mixMsg.protocol)
+proc serialize*(mixMsg: MixMessage): Result[seq[byte], string] =
+  if mixMsg.codec.len == 0:
+    return err("serialization failed: codec cannot be empty")
 
-proc serializeMixMessage*(mixMsg: MixMessage): Result[seq[byte], string] =
-  try:
-    let
-      msgBytes = mixMsg.message
-      protocolBytes = uint16ToBytes(uint16(mixMsg.protocol))
-    return ok(msgBytes & protocolBytes)
-  except Exception as e:
-    error "Failed to serialize MixMessage", err = e.msg
-    return err("Serialization failed: " & e.msg)
+  let vbytes = toBytes(mixMsg.codec.len.uint64, Leb128)
+  if vbytes.len > 2:
+    return err("serialization failed: codec length exceeds 2 bytes")
 
-proc deserializeMixMessage*(data: openArray[byte]): Result[MixMessage, string] =
-  try:
-    let message = data[0 ..^ (protocolTypeSize + 1)]
+  var buf =
+    newSeqUninitialized[byte](vbytes.len + mixMsg.codec.len + mixMsg.message.len)
+  buf[0 ..< vbytes.len] = vbytes.toOpenArray()
+  buf[vbytes.len ..< mixMsg.codec.len] = mixMsg.codec.toBytes()
+  buf[vbytes.len + mixMsg.codec.len ..< buf.len] = mixMsg.message
+  ok(buf)
 
-    let res = bytesToUInt16(data[^protocolTypeSize ..^ 1])
-    if res.isErr:
-      return err(res.error)
-    let protocol = ProtocolType(res.get())
+proc deserialize*(
+    T: typedesc[MixMessage], data: openArray[byte]
+): Result[MixMessage, string] =
+  if data.len == 0:
+    return err("deserialization failed: data is empty")
 
-    return ok(MixMessage(message: message, protocol: protocol))
-  except Exception as e:
-    error "Failed to deserialize MixMessage", err = e.msg
-    return err("Deserialization failed: " & e.msg)
+  var codecLen: int
+  var varintLen: int
+  for i in 0 ..< min(data.len, 2):
+    let parsed = uint16.fromBytes(data[0 ..< i], Leb128)
+    if parsed.len < 0 or (i == 1 and parsed.len == 0):
+      return err("deserialization failed: invalid codec length")
 
-proc serializeMixMessageAndDestination*(
+    varintLen = parsed.len
+    codecLen = parsed.val.int
+
+  if data.len < varintLen + codecLen:
+    return err("deserialization failed: not enough data")
+
+  ok(
+    T(
+      codec: string.fromBytes(data[varintLen ..< varintLen + codecLen]),
+      message: data[varintLen + codecLen ..< data.len],
+    )
+  )
+
+# TODO: These are not used anywhere
+# TODO: consider changing the `dest` parameter to a multiaddress
+proc serializeWithDestination*(
     mixMsg: MixMessage, dest: string
 ): Result[seq[byte], string] =
-  try:
-    let
-      msgBytes = mixMsg.message
-      protocolBytes = uint16ToBytes(uint16(mixMsg.protocol))
+  let destBytes = multiAddrToBytes(dest).valueOr:
+    return err("Error in multiaddress conversion to bytes: " & error)
 
-    let destBytes = multiAddrToBytes(dest).valueOr:
-      return err("Error in multiaddress conversion to bytes: " & error)
+  if len(destBytes) != addrSize:
+    error "Destination address must be exactly " & $addrSize & " bytes"
+    return err("Destination address must be exactly " & $addrSize & " bytes")
 
-    if len(destBytes) != addrSize:
-      error "Destination address must be exactly " & $addrSize & " bytes"
-      return err("Destination address must be exactly " & $addrSize & " bytes")
+  var serializedMixMsg = ?mixMsg.serialize()
+  let oldLen = serializedMixMsg.len
+  serializedMixMsg.setLen(oldLen + destBytes.len)
+  copyMem(addr serializedMixMsg[oldLen], unsafeAddr destBytes[0], destBytes.len)
 
-    return ok(msgBytes & protocolBytes & destBytes)
-  except Exception as e:
-    error "Failed to serialize MixMessage and destination", err = e.msg
-    return err("Serialization with destination failed: " & e.msg)
+  return ok(serializedMixMsg)
 
-proc deserializeMixMessageAndDestination*(
-    data: openArray[byte]
-): Result[(seq[byte], string), string] =
-  try:
-    let mixMsg = data[0 ..^ (addrSize + 1)]
+# TODO: These are not used anywhere
+proc deserializeWithDestination*(
+    T: typedesc[MixMessage], data: openArray[byte]
+): Result[(T, string), string] =
+  if data.len <= addrSize:
+    return err("Deserialization with destination failed: not enough data")
 
-    let dest = bytesToMultiAddr(data[^addrSize ..^ 1]).valueOr:
-      return err("Error in destination multiaddress conversion to bytes: " & error)
+  let mixMsg = ?MixMessage.deserialize(data[0 ..^ (addrSize + 1)])
 
-    return ok((mixMsg, dest))
-  except Exception as e:
-    return err("Deserialization with destination failed: " & e.msg)
+  let dest = bytesToMultiAddr(data[^addrSize ..^ 1]).valueOr:
+    return err("Error in destination multiaddress conversion to bytes: " & error)
+
+  return ok((mixMsg, dest))


### PR DESCRIPTION
In this PR i remove the need to have an enum containing the protocols that mix support, by using a 2 bytes varint + the codec string when serializing the `MixMessage` object. Since with this change the max length for a message can change depending on the length of the codec, I provide a `getMaxPayloadSizeForCodec` which top level applications can use to determine the max message length. 


cc: @chaitanyaprem



Btw, @AkshayaMani, @Ben-PH, two questions:
-  We do use `message` as an attribute within MixMessage and also as parameter in some other procs. Shouldn't it be called `data` instead to indicate that this is a payload?
- I renamed `protocol` attributes/params to `codec` to be consistent with libp2p. Is this okay? or should i have kept it as `protocol`?