### PR TITLE
chore: use `new`/`init` and naming of res variables

### DIFF
--- a/mix/curve25519.nim
+++ b/mix/curve25519.nim
@@ -50,7 +50,3 @@ proc multiplyBasePointWithScalars*(
   for i in 1 ..< scalars.len:
     Curve25519.mul(res, scalars[i]) # Multiply with each scalar
   ok(res)
-
-# Compare two FieldElements
-proc compareFieldElements*(a, b: FieldElement): bool =
-  a == b

--- a/mix/entry_connection.nim
+++ b/mix/entry_connection.nim
@@ -36,7 +36,7 @@ method readLp*(
 method write*(
     self: MixEntryConnection, msg: seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
-  self.mixDialer(@msg, self.codec, self.destMultiAddr, self.destPeerId)
+  self.mixDialer(msg, self.codec, self.destMultiAddr, self.destPeerId)
 
 proc write*(
     self: MixEntryConnection, msg: string

--- a/mix/exit_connection.nim
+++ b/mix/exit_connection.nim
@@ -139,7 +139,7 @@ method closeImpl*(
 func hash*(self: MixExitConnection): Hash =
   discard
 
-proc new*(T: typedesc[MixExitConnection], message: seq[byte]): MixExitConnection =
+proc new*(T: typedesc[MixExitConnection], message: seq[byte]): T =
   let instance = T(message: message)
 
   when defined(libp2p_agents_metrics):

--- a/mix/mix_message.nim
+++ b/mix/mix_message.nim
@@ -7,7 +7,7 @@ type MixMessage* = object
   message*: seq[byte]
   codec*: string
 
-proc new*(T: typedesc[MixMessage], message: openArray[byte], codec: string): T =
+proc init*(T: typedesc[MixMessage], message: openArray[byte], codec: string): T =
   return T(message: @message, codec: codec)
 
 proc serialize*(mixMsg: MixMessage): Result[seq[byte], string] =

--- a/mix/seqno_generator.nim
+++ b/mix/seqno_generator.nim
@@ -5,8 +5,8 @@ import ./crypto
 type SeqNo* = object
   counter: uint32
 
-proc initSeqNo*(peerId: PeerId): SeqNo =
-  var seqNo: SeqNo
+proc init*(T: typedesc[SeqNo], peerId: PeerId): T =
+  var seqNo = T()
   let peerIdHash = sha256_hash(peerId.data)
   for i in 0 .. 3:
     seqNo.counter = seqNo.counter or (uint32(peerIdHash[i]) shl (8 * (3 - i)))

--- a/mix/tag_manager.nim
+++ b/mix/tag_manager.nim
@@ -5,8 +5,8 @@ type TagManager* = ref object
   lock: Lock
   seenTags: Table[FieldElement, bool]
 
-proc initTagManager*(): TagManager =
-  let tm = new(TagManager)
+proc new*(T: typedesc[TagManager]): T =
+  let tm = T()
   tm.seenTags = initTable[FieldElement, bool]()
   initLock(tm.lock)
   return tm

--- a/tests/test_curve25519.nim
+++ b/tests/test_curve25519.nim
@@ -41,7 +41,7 @@ suite "curve25519_tests":
       fail()
     let derivedPublicKey = derivedPublicKeyResult.get()
 
-    if not compareFieldElements(publicKey, derivedPublicKey):
+    if publicKey != derivedPublicKey:
       error "Public keydoes not match derived key",
         publickey = publicKey, derivedkey = derivedPublicKey
       fail()
@@ -69,6 +69,6 @@ suite "curve25519_tests":
       intermediate = public(x2)
       res2 = multiplyPointWithScalars(intermediate, @[x1])
 
-    if not compareFieldElements(res1, res2):
+    if res1 != res2:
       error "Field element operations must be commutative", res1 = res1, res2 = res2
       fail()

--- a/tests/test_fragmentation.nim
+++ b/tests/test_fragmentation.nim
@@ -14,13 +14,13 @@ suite "Fragmentation":
       chunks = padAndChunkMessage(message, peerId)
       (paddingLength, data, seqNo) = getMessageChunk(chunks[0])
 
-    let serializedRes = serializeMessageChunk(chunks[0])
+    let serializedRes = chunks[0].serialize()
     if serializedRes.isErr:
       error "Serialization error", err = serializedRes.error
       fail()
     let serialized = serializedRes.get()
 
-    let deserializedRes = deserializeMessageChunk(serialized)
+    let deserializedRes = MessageChunk.deserialize(serialized)
     if deserializedRes.isErr:
       error "Deserialization error", err = deserializedRes.error
       fail()

--- a/tests/test_mix_message.nim
+++ b/tests/test_mix_message.nim
@@ -10,7 +10,7 @@ suite "mix_message_tests":
     let
       message = "Hello World!"
       codec = "/test/codec/1.0.0"
-      mixMsg = MixMessage.new(message.toBytes(), codec)
+      mixMsg = MixMessage.init(message.toBytes(), codec)
 
     let serializedResult = mixMsg.serialize()
     if serializedResult.isErr:
@@ -40,7 +40,7 @@ suite "mix_message_tests":
     let
       emptyMessage = ""
       codec = "/test/codec/1.0.0"
-      mixMsg = MixMessage.new(emptyMessage.toBytes(), codec)
+      mixMsg = MixMessage.init(emptyMessage.toBytes(), codec)
 
     let serializedResult = mixMsg.serialize()
     if serializedResult.isErr:
@@ -69,7 +69,7 @@ suite "mix_message_tests":
       codec = "/test/codec/1.0.0"
       destination =
         "/ip4/0.0.0.0/tcp/4242/p2p/16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC"
-      mixMsg = MixMessage.new(message.toBytes(), codec)
+      mixMsg = MixMessage.init(message.toBytes(), codec)
 
     let serializedResult = mixMsg.serializeWithDestination(destination)
     if serializedResult.isErr:

--- a/tests/test_mix_node.nim
+++ b/tests/test_mix_node.nim
@@ -102,12 +102,12 @@ suite "Mix Node Tests":
           multiaddr = fMultiAddr, original = multiAddr
         fail()
 
-      if not compareFieldElements(fMixPubKey, mixPubKey):
+      if fMixPubKey != mixPubKey:
         error "Mix public key does not match original mix public key",
           pubkey = fMixPubKey, original = mixPubKey
         fail()
 
-      if not compareFieldElements(fMixPrivKey, mixPrivKey):
+      if fMixPrivKey != mixPrivKey:
         error "Mix private key does not match original mix private key",
           privkey = fMixPrivKey, original = mixPrivKey
         fail()
@@ -167,12 +167,12 @@ suite "Mix Node Tests":
           multiaddr = rMultiAddr, original = multiAddr
         fail()
 
-      if not compareFieldElements(rMixPubKey, mixPubKey):
+      if rMixPubKey != mixPubKey:
         error "Mix public key does not match original mix public key",
           pubkey = rMixPubKey, original = mixPubKey
         fail()
 
-      if not compareFieldElements(rMixPrivKey, mixPrivKey):
+      if rMixPrivKey != mixPrivKey:
         error "Mix private key does not match original mix private key",
           privkey = rMixPrivKey, original = mixPrivKey
         fail()
@@ -215,7 +215,7 @@ suite "Mix Node Tests":
           multiaddr = rMultiAddr, original = multiAddr
         fail()
 
-      if not compareFieldElements(rMixPubKey, mixPubKey):
+      if rMixPubKey != mixPubKey:
         error "Mix public key does not match original mix public key",
           pubkey = rMixPubKey, original = mixPubKey
         fail()

--- a/tests/test_seqno_generator.nim
+++ b/tests/test_seqno_generator.nim
@@ -10,7 +10,7 @@ suite "Sequence Number Generator":
     let
       peerId =
         PeerId.init("16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC").get()
-      seqNo = initSeqNo(peerId)
+      seqNo = SeqNo.init(peerId)
     if seqNo.counter == 0:
       error "Sequence number initialization failed", counter = seqNo.counter
       fail()
@@ -21,7 +21,7 @@ suite "Sequence Number Generator":
         PeerId.init("16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC").get()
       msg1 = @[byte 1, 2, 3]
       msg2 = @[byte 4, 5, 6]
-    var seqNo = initSeqNo(peerId)
+    var seqNo = SeqNo.init(peerId)
 
     generateSeqNo(seqNo, msg1)
     let seqNo1 = seqNo.counter
@@ -39,7 +39,7 @@ suite "Sequence Number Generator":
       peerId =
         PeerId.init("16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC").get()
       msg = @[byte 1, 2, 3]
-    var seqNo = initSeqNo(peerId)
+    var seqNo = SeqNo.init(peerId)
 
     generateSeqNo(seqNo, msg)
     let seqNo1 = seqNo.counter
@@ -61,8 +61,8 @@ suite "Sequence Number Generator":
         PeerId.init("16Uiu2HAm6WNzw8AssyPscYYi8x1bY5wXyQrGTShRH75bh5dPCjBQ").get()
 
     var
-      seqNo1 = initSeqNo(peerId1)
-      seqNo2 = initSeqNo(peerId2)
+      seqNo1 = SeqNo.init(peerId1)
+      seqNo2 = SeqNo.init(peerId2)
 
     if seqNo1.counter == seqNo2.counter:
       error "Sequence numbers for different peer IDs should be different",
@@ -72,7 +72,7 @@ suite "Sequence Number Generator":
   test "increment_seq_no":
     let peerId =
       PeerId.init("16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC").get()
-    var seqNo: SeqNo = initSeqNo(peerId)
+    var seqNo: SeqNo = SeqNo.init(peerId)
     let initialCounter = seqNo.counter
 
     incSeqNo(seqNo)
@@ -85,7 +85,7 @@ suite "Sequence Number Generator":
   test "seq_no_wraps_around_at_max_value":
     let peerId =
       PeerId.init("16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC").get()
-    var seqNo = initSeqNo(peerId)
+    var seqNo = SeqNo.init(peerId)
     seqNo.counter = high(uint32) - 1
     if seqNo.counter != high(uint32) - 1:
       error "Sequence number must be max value",
@@ -101,7 +101,7 @@ suite "Sequence Number Generator":
     let peerId =
       PeerId.init("16Uiu2HAmFkwLVsVh6gGPmSm9R3X4scJ5thVdKfWYeJsKeVrbcgVC").get()
     var
-      seqNo = initSeqNo(peerId)
+      seqNo = SeqNo.init(peerId)
       seenValues = initHashSet[uint32]()
 
     for i in 0 ..< 10000:

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -6,11 +6,11 @@ import ../mix/[config, serialization]
 # Define test cases
 suite "serialization_tests":
   test "serialize_and_deserialize_header":
-    let header = initHeader(
+    let header = Header.init(
       newSeq[byte](alphaSize), newSeq[byte](betaSize), newSeq[byte](gammaSize)
     )
 
-    let serializedRes = serializeHeader(header)
+    let serializedRes = header.serialize()
     if serializedRes.isErr:
       error "Failed to serialize header", err = serializedRes.error
       fail()
@@ -22,34 +22,34 @@ suite "serialization_tests":
       fail()
 
   test "serialize_and_deserialize_message":
-    let message = initMessage(newSeq[byte](messageSize))
+    let message = Message.init(newSeq[byte](messageSize))
 
-    let serializedRes = serializeMessage(message)
+    let serializedRes = message.serialize()
     if serializedRes.isErr:
       error "Failed to serialize message", err = serializedRes.error
       fail()
     let serialized = serializedRes.get()
 
-    let deserializedRes = deserializeMessage(serialized)
+    let deserializedRes = Message.deserialize(serialized)
     if deserializedRes.isErr:
       error "Failed to deserialize message", err = deserializedRes.error
       fail()
     let deserialized = deserializedRes.get()
 
-    if getMessage(message) != getMessage(deserialized):
+    if getContent(message) != getContent(deserialized):
       error "Deserialized message does not match the original message"
       fail()
 
   test "serialize_and_deserialize_hop":
-    let hop = initHop(newSeq[byte](addrSize))
+    let hop = Hop.init(newSeq[byte](addrSize))
 
-    let serializedRes = serializeHop(hop)
+    let serializedRes = hop.serialize()
     if serializedRes.isErr:
       error "Failed to serialize hop", err = serializedRes.error
       fail()
     let serialized = serializedRes.get()
 
-    let deserializedRes = deserializeHop(serialized)
+    let deserializedRes = Hop.deserialize(serialized)
     if deserializedRes.isErr:
       error "Failed to deserialize hop", err = deserializedRes.error
       fail()
@@ -60,14 +60,14 @@ suite "serialization_tests":
       fail()
 
   test "serialize_and_deserialize_routing_info":
-    let routingInfo = initRoutingInfo(
-      initHop(newSeq[byte](addrSize)),
+    let routingInfo = RoutingInfo.init(
+      Hop.init(newSeq[byte](addrSize)),
       newSeq[byte](delaySize),
       newSeq[byte](gammaSize),
       newSeq[byte](((r * (t + 1)) - t) * k),
     )
 
-    let serializedRes = serializeRoutingInfo(routingInfo)
+    let serializedRes = routingInfo.serialize()
     if serializedRes.isErr:
       error "Failed to serialize routing info", err = serializedRes.error
       fail()
@@ -77,7 +77,7 @@ suite "serialization_tests":
       suffixLength = (t + 1) * k
       suffix = newSeq[byte](suffixLength)
 
-    let deserializedRes = deserializeRoutingInfo(serialized & suffix)
+    let deserializedRes = RoutingInfo.deserialize(serialized & suffix)
     if deserializedRes.isErr:
       error "Failed to deserialize routing info", err = deserializedRes.error
       fail()
@@ -105,19 +105,19 @@ suite "serialization_tests":
 
   test "serialize_and_deserialize_sphinx_packet":
     let
-      header = initHeader(
+      header = Header.init(
         newSeq[byte](alphaSize), newSeq[byte](betaSize), newSeq[byte](gammaSize)
       )
       payload = newSeq[byte](payloadSize)
-      packet = initSphinxPacket(header, payload)
+      packet = SphinxPacket.init(header, payload)
 
-    let serializedRes = serializeSphinxPacket(packet)
+    let serializedRes = packet.serialize()
     if serializedRes.isErr:
       error "Failed to serialize sphinx packet", err = serializedRes.error
       fail()
     let serialized = serializedRes.get()
 
-    let deserializedRes = deserializeSphinxPacket(serialized)
+    let deserializedRes = SphinxPacket.deserialize(serialized)
     if deserializedRes.isErr:
       error "Failed to deserialize sphinx packet", err = deserializedRes.error
       fail()

--- a/tests/test_sphinx.nim
+++ b/tests/test_sphinx.nim
@@ -42,12 +42,12 @@ proc createDummyData(): (
 
     hops =
       @[
-        initHop(newSeq[byte](addrSize)),
-        initHop(newSeq[byte](addrSize)),
-        initHop(newSeq[byte](addrSize)),
+        Hop.init(newSeq[byte](addrSize)),
+        Hop.init(newSeq[byte](addrSize)),
+        Hop.init(newSeq[byte](addrSize)),
       ]
 
-    message = initMessage(newSeq[byte](messageSize))
+    message = Message.init(newSeq[byte](messageSize))
 
   return (message, privateKeys, publicKeys, delay, hops)
 
@@ -56,7 +56,7 @@ suite "Sphinx Tests":
   var tm: TagManager
 
   setup:
-    tm = initTagManager()
+    tm = TagManager.new()
 
   teardown:
     clearTags(tm)
@@ -114,7 +114,7 @@ suite "Sphinx Tests":
       error "Processing status should be Exit"
       fail()
 
-    let processedMessage = initMessage(processedPacket3)
+    let processedMessage = Message.init(processedPacket3)
     if processedMessage != message:
       error "Packet processing failed"
       fail()
@@ -199,7 +199,7 @@ suite "Sphinx Tests":
       let paddedMessage = padMessage(message, messageSize)
 
       let packetRes = wrapInSphinxPacket(
-        initMessage(paddedMessage), publicKeys, delay, hops, Opt.none(Hop)
+        Message.init(paddedMessage), publicKeys, delay, hops, Opt.none(Hop)
       )
       if packetRes.isErr:
         error "Sphinx wrap error", err = packetRes.error

--- a/tests/test_tag_manager.nim
+++ b/tests/test_tag_manager.nim
@@ -7,7 +7,7 @@ suite "tag_manager_tests":
   var tm: TagManager
 
   setup:
-    tm = initTagManager()
+    tm = TagManager.new()
 
   teardown:
     clearTags(tm)


### PR DESCRIPTION
- `new` is used for those that return references
- `init` for those that return values
- Also changed the name of some `*res` variables that were result of `valueOr`, and use `==` for field elements directly
- renamed serialize/deserialize procs