### PR TITLE
feat: create surbs and send response back

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,4 +14,5 @@ jobs:
        nimble c ./examples/poc_gossipsub.nim
        nimble c ./examples/poc_gossipsub_repeated_runs.nim
        nimble c ./examples/poc_noresp_ping.nim
+       nimble c ./examples/poc_resp_ping.nim
       nim-versions: '["version-2-0", "version-2-2", "devel"]'

--- a/examples/poc_gossipsub.nim
+++ b/examples/poc_gossipsub.nim
@@ -114,7 +114,7 @@ proc makeMixConnCb(mixProto: MixProtocol): CustomConnCreationProc =
       destAddr: Option[MultiAddress], destPeerId: PeerId, codec: string
   ): Connection {.gcsafe, raises: [].} =
     try:
-      return mixProto.toConnection(destPeerId, codec)
+      return mixProto.toConnection(destPeerId, codec).get()
     except CatchableError as e:
       error "Error during execution of MixEntryConnection callback: ", err = e.msg
       return nil

--- a/examples/poc_gossipsub_repeated_runs.nim
+++ b/examples/poc_gossipsub_repeated_runs.nim
@@ -116,7 +116,7 @@ proc makeMixConnCb(mixProto: MixProtocol): CustomConnCreationProc =
       destAddr: Option[MultiAddress], destPeerId: PeerId, codec: string
   ): Connection {.gcsafe, raises: [].} =
     try:
-      return mixProto.toConnection(destPeerId, codec)
+      return mixProto.toConnection(destPeerId, codec).get()
     except CatchableError as e:
       error "Error during execution of MixEntryConnection callback: ", err = e.msg
       return nil

--- a/examples/poc_noresp_ping.nim
+++ b/examples/poc_noresp_ping.nim
@@ -85,7 +85,7 @@ proc mixnetSimulation() {.async: (raises: [Exception]).} =
 
     let proto = MixProtocol.new(index, numberOfNodes, nodes[index]).valueOr:
       error "Mix protocol initialization failed", err = error
-      return
+      return # We'll fwd requests, so let's register how should the exit node behave
 
     mixProto.add(proto)
 

--- a/examples/poc_resp_ping.nim
+++ b/examples/poc_resp_ping.nim
@@ -84,18 +84,9 @@ proc mixnetSimulation() {.async: (raises: [Exception]).} =
       error "Mix protocol initialization failed", err = error
       return
 
-    # We'll fwd requests, so let's register how should the exit node behave
-    proto.registerFwdReadBehavior(
-      PingCodec,
-      proc(
-          conn: Connection
-      ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
-        debug "reading ping from destination"
-        let resultBuf = newSeqUninitialized[byte](32)
-        await conn.readExactly(addr resultBuf[0], 32)
-        return resultBuf,
-    )
-
+    # We'll fwd requests, so let's register how should the exit node will read responses
+    proto.registerFwdReadBehavior(PingCodec, readExactly(32))
+    
     mixProto.add(proto)
 
     nodes[index].mount(pingProto[index])

--- a/examples/poc_resp_ping.nim
+++ b/examples/poc_resp_ping.nim
@@ -85,15 +85,13 @@ proc mixnetSimulation() {.async: (raises: [Exception]).} =
       return
 
     # We'll fwd requests, so let's register how should the exit node behave
-    proto.registerFwdBehavior(
+    proto.registerFwdReadBehavior(
       PingCodec,
       proc(
-          conn: Connection, msg: seq[byte]
+          conn: Connection
       ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
-        debug "writing ping to destination"
-        await conn.write(msg)
         debug "reading ping from destination"
-        let resultBuf = newSeqUninit[byte](32)
+        let resultBuf = newSeqUninitialized[byte](32)
         await conn.readExactly(addr resultBuf[0], 32)
         return resultBuf,
     )

--- a/mix.nim
+++ b/mix.nim
@@ -1,4 +1,6 @@
 import results
+import chronos
+import libp2p
 import ./mix/[mix_protocol, mix_node, entry_connection, exit_layer]
 
 export results
@@ -24,3 +26,17 @@ export mixNode
 export MixParameters
 export fwdReadBehaviorCb
 export registerFwdReadBehavior
+
+proc readLp*(maxSize: int): fwdReadBehaviorCb =
+  return proc(
+      conn: Connection
+  ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
+    await conn.readLp(maxSize)
+
+proc readExactly*(nBytes: int): fwdReadBehaviorCb =
+  return proc(
+      conn: Connection
+  ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
+    let buf = newSeqUninitialized[byte](nBytes)
+    await conn.readExactly(addr buf[0], nBytes)
+    return buf

--- a/mix.nim
+++ b/mix.nim
@@ -22,5 +22,5 @@ export DestinationType
 export forwardToAddr
 export mixNode
 export MixParameters
-export fwdBehaviorCb
-export registerFwdBehavior
+export fwdReadBehaviorCb
+export registerFwdReadBehavior

--- a/mix.nim
+++ b/mix.nim
@@ -1,5 +1,5 @@
 import results
-import ./mix/[mix_protocol, mix_node, entry_connection]
+import ./mix/[mix_protocol, mix_node, entry_connection, exit_layer]
 
 export results
 
@@ -21,3 +21,6 @@ export Destination
 export DestinationType
 export forwardToAddr
 export mixNode
+export MixParameters
+export fwdBehaviorCb
+export registerFwdBehavior

--- a/mix/config.nim
+++ b/mix/config.nim
@@ -12,3 +12,8 @@ const
   packetSize* = 4608 # Total packet size (from spec)
   messageSize* = packetSize - headerSize - k # Size of the message itself
   payloadSize* = messageSize + k # Total payload size
+  surbSize* = headerSize + k + addrSize
+    # Size of a surb packet inside the message payload
+  surbLenSize* = 1 # Size of the field storing the number of surbs
+  surbIdLen* = 16 # Size of the identifier used when sending a message with surb
+  defaultSurbs* = uint8(4) # Default number of SURBs to send

--- a/mix/entry_connection.nim
+++ b/mix/entry_connection.nim
@@ -183,7 +183,9 @@ proc toConnection*(
     else:
       destination
 
-  if dest.kind == DestinationType.ForwardAddr and not srcMix.hasFwdBehavior(codec):
+  if dest.kind == DestinationType.ForwardAddr and
+      params.get(MixParameters()).expectReply.get(false) and
+      not srcMix.hasFwdBehavior(codec):
     return err("no forward behavior for codec")
 
   ok(MixEntryConnection.new(srcMix, dest, codec, params))

--- a/mix/exit_layer.nim
+++ b/mix/exit_layer.nim
@@ -1,15 +1,27 @@
 import std/[enumerate, strutils]
 import chronicles, chronos, metrics
 import libp2p, libp2p/[builders, stream/connection]
-import ./[mix_metrics, exit_connection, serialization, utils]
+import
+  ./[
+    mix_metrics, exit_connection, reply_connection, serialization, utils # fragmentation
+  ]
+
+type OnReplyDialer* =
+  proc(surb: SURB, message: seq[byte]) {.async: (raises: [CancelledError]).}
 
 type ProtocolHandler* = proc(conn: Connection, codec: string): Future[void] {.
   async: (raises: [CancelledError])
 .}
 
+type fwdBehaviorCb* = proc(conn: Connection, msg: seq[byte]): Future[seq[byte]] {.
+  async: (raises: [CancelledError, LPStreamError])
+.}
+
 type ExitLayer* = object
   switch: Switch
   pHandler: ProtocolHandler
+  onReplyDialer: OnReplyDialer
+  fwdRWBehavior: TableRef[string, fwdBehaviorCb]
 
 proc callHandler(
     switch: Switch, conn: Connection, codec: string
@@ -18,11 +30,19 @@ proc callHandler(
     if codec in handler.protos:
       await handler.protocol.handler(conn, codec)
       return
+
   error "Handler doesn't exist", codec = codec
 
-proc init*(T: typedesc[ExitLayer], switch: Switch): T =
+proc init*(
+    T: typedesc[ExitLayer],
+    switch: Switch,
+    onReplyDialer: OnReplyDialer,
+    fwdRWBehavior: TableRef[string, fwdBehaviorCb],
+): T =
   ExitLayer(
     switch: switch,
+    onReplyDialer: onReplyDialer,
+    fwdRWBehavior: fwdRWBehavior,
     pHandler: proc(
         conn: Connection, codec: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
@@ -33,26 +53,68 @@ proc init*(T: typedesc[ExitLayer], switch: Switch): T =
     ,
   )
 
-proc runHandler(
-    self: ExitLayer, codec: string, message: seq[byte]
+proc replyDialerCbFactory(self: ExitLayer): MixReplyDialer =
+  return proc(
+      surbs: seq[SURB], msg: seq[byte]
+  ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
+    try:
+      var respFuts: seq[Future[void]] = @[]
+      for surb in surbs:
+        respFuts.add(self.onReplyDialer(surb, msg))
+      await allFutures(respFuts)
+    except CancelledError as e:
+      raise e
+    except CatchableError as e:
+      error "Error during execution of reply: ", err = e.msg
+    return
+
+proc reply(
+    self: ExitLayer, surbs: seq[SURB], response: seq[byte]
 ) {.async: (raises: [CancelledError]).} =
+  if surbs.len == 0:
+    return
+
+  echo "\e[0;31mREPLYING>>>>>>>>>>>>>>>>>>>>>>>>>", response, "\e[0m"
+  let replyConn = MixReplyConnection.new(surbs, self.replyDialerCbFactory())
+  defer:
+    if not replyConn.isNil:
+      await replyConn.close()
+  try:
+    await replyConn.writeLp(response)
+  except LPStreamError as exc:
+    error "could not reply", description = exc.msg
+    mix_messages_error.inc(labelValues = ["ExitLayer", "REPLY_FAILED"])
+
+proc runHandler(
+    self: ExitLayer, codec: string, message: seq[byte], surbs: seq[SURB]
+) {.async: (raises: [CancelledError]).} =
+  echo "Exit is handling request >>>>"
   let exitConn = MixExitConnection.new(message)
+  defer:
+    if not exitConn.isNil:
+      await exitConn.close()
 
   await self.pHandler(exitConn, codec)
 
-  try:
-    await exitConn.close()
-  except CatchableError as e:
-    error "Failed to close exit connection: ", err = e.msg
-  return
+  if surbs.len != 0:
+    let response = exitConn.getResponse()
+    await self.reply(surbs, response)
 
 proc onMessage*(
-    self: ExitLayer, codec: string, message: seq[byte], nextHop: Hop
+    self: ExitLayer, codec: string, message: seq[byte], nextHop: Hop, surbs: seq[SURB]
 ) {.async: (raises: [CancelledError]).} =
   if nextHop == Hop():
     trace "onMessage - exit is destination", codec, message
-    await self.runHandler(codec, message)
+    await self.runHandler(codec, message, surbs)
     return
+
+  echo "\e[0;32m>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+  echo ">>>>>>>>    REPLYING      >>>>>>>>"
+  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\e[0m"
 
   # Forward to destination
   let destBytes = getHop(nextHop)
@@ -81,14 +143,28 @@ proc onMessage*(
 
   trace "onMessage - exit is not destination", peerId, locationAddr, codec, message
 
-  var destConn: Connection
+  if not self.fwdRWBehavior.hasKey(codec):
+    error "No fwdRWBehavior for codec", codec
+    return
+
+  var behaviorCb: fwdBehaviorCb
   try:
+    behaviorCb = self.fwdRWBehavior[codec]
+  except KeyError:
+    doAssert false, "checked with HasKey"
+
+  var destConn: Connection
+  var response: seq[byte]
+  try:
+    echo "EXIT IS DIALING: ", peerId, locationAddr
     destConn = await self.switch.dial(peerId, @[locationAddr], codec)
-    await destConn.writeLp(message)
-    #TODO: When response is implemented, we can read the response here
+    response = await behaviorCb(destConn, message)
   except CatchableError as e:
     error "Failed to dial next hop: ", err = e.msg
     mix_messages_error.inc(labelValues = ["ExitLayer", "DIAL_FAILED"])
+    return
   finally:
     if not destConn.isNil:
       await destConn.close()
+
+  await self.reply(surbs, response)

--- a/mix/mix_message.nim
+++ b/mix/mix_message.nim
@@ -10,9 +10,6 @@ proc init*(T: typedesc[MixMessage], message: openArray[byte], codec: string): T 
   return T(message: @message, codec: codec)
 
 proc serialize*(mixMsg: MixMessage): Result[seq[byte], string] =
-  if mixMsg.codec.len == 0:
-    return err("serialization failed: codec cannot be empty")
-
   let vbytes = toBytes(mixMsg.codec.len.uint64, Leb128)
   if vbytes.len > 2:
     return err("serialization failed: codec length exceeds 2 bytes")

--- a/mix/mix_protocol.nim
+++ b/mix/mix_protocol.nim
@@ -271,13 +271,7 @@ proc buildSurbs(
 
       i = i + 1
 
-    let (destAddr, _, _, _, _) = getMixNodeInfo(mixProto.mixNodeInfo)
-    let destAddrBytes = multiAddrToBytes(destAddr).valueOr:
-      mix_messages_error.inc(labelValues = ["Entry/SURBS", "INVALID_DEST"])
-      return err("failed to convert multiaddress to bytes: " & error)
-    let dest = Hop.init(destAddrBytes)
-
-    let surb = createSURB(publicKeys, delay, hops, dest, id).valueOr:
+    let surb = createSURB(publicKeys, delay, hops, Hop(), id).valueOr:
       return err(error)
 
     surbSK.add((surb.secret.get(), surb.key))

--- a/mix/reply_connection.nim
+++ b/mix/reply_connection.nim
@@ -1,0 +1,104 @@
+import hashes, chronos, stew/byteutils, results, chronicles
+import libp2p/stream/connection
+import libp2p
+import ./[serialization]
+from fragmentation import dataSize
+
+type MixReplyDialer* = proc(surbs: seq[SURB], msg: seq[byte]): Future[void] {.
+  async: (raises: [CancelledError, LPStreamError], raw: true)
+.}
+
+type MixReplyConnection* = ref object of Connection
+  surbs: seq[SURB]
+  mixReplyDialer: MixReplyDialer
+
+method readExactly*(
+    self: MixReplyConnection, pbytes: pointer, nbytes: int
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+  raise
+    newException(LPStreamError, "readExactly not implemented for MixReplyConnection")
+
+method readLine*(
+    self: MixReplyConnection, limit = 0, sep = "\r\n"
+): Future[string] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+  raise newException(LPStreamError, "readLine not implemented for MixReplyConnection")
+
+method readVarint*(
+    self: MixReplyConnection
+): Future[uint64] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+  raise newException(LPStreamError, "readVarint not implemented for MixReplyConnection")
+
+method readLp*(
+    self: MixReplyConnection, maxSize: int
+): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+  raise newException(LPStreamError, "readLp not implemented for MixReplyConnection")
+
+method write*(
+    self: MixReplyConnection, msg: seq[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
+  self.mixReplyDialer(self.surbs, msg)
+
+proc write*(
+    self: MixReplyConnection, msg: string
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
+  self.write(msg.toBytes())
+
+method writeLp*(
+    self: MixReplyConnection, msg: openArray[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
+  if msg.len() > dataSize:
+    let fut = newFuture[void]()
+    fut.fail(
+      newException(LPStreamError, "exceeds max msg size of " & $dataSize & " bytes")
+    )
+    return fut
+
+  var
+    vbytes: seq[byte] = @[]
+    value = msg.len().uint64
+
+  while value >= 128:
+    vbytes.add(byte((value and 127) or 128))
+    value = value shr 7
+  vbytes.add(byte(value))
+
+  var buf = newSeqUninitialized[byte](msg.len() + vbytes.len)
+  buf[0 ..< vbytes.len] = vbytes.toOpenArray(0, vbytes.len - 1)
+  buf[vbytes.len ..< buf.len] = msg
+
+  self.mixReplyDialer(self.surbs, @buf)
+
+method writeLp*(
+    self: MixReplyConnection, msg: string
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
+  self.writeLp(msg.toOpenArrayByte(0, msg.high))
+
+proc shortLog*(self: MixReplyConnection): string {.raises: [].} =
+  "[MixReplyConnection]"
+
+method initStream*(self: MixReplyConnection) =
+  discard
+
+method closeImpl*(
+    self: MixReplyConnection
+): Future[void] {.async: (raises: [], raw: true).} =
+  let fut = newFuture[void]()
+  fut.complete()
+  return fut
+
+func hash*(self: MixReplyConnection): Hash =
+  hash($self.surbs)
+
+when defined(libp2p_agents_metrics):
+  proc setShortAgent*(self: MixReplyConnection, shortAgent: string) =
+    discard
+
+proc new*(
+    T: typedesc[MixReplyConnection], surbs: seq[SURB], mixReplyDialer: MixReplyDialer
+): T =
+  let instance = T(surbs: surbs, mixReplyDialer: mixReplyDialer)
+
+  when defined(libp2p_agents_metrics):
+    instance.shortAgent = connection.shortAgent
+
+  instance

--- a/mix/serialization.nim
+++ b/mix/serialization.nim
@@ -1,6 +1,5 @@
 import results
 import ./config
-import bearssl/rand
 import std/sequtils
 
 type Header* = object
@@ -183,7 +182,7 @@ type
     secret*: Opt[secret]
 
 proc serializeMessageWithSURBs*(
-    msg: seq[byte], surbs: seq[SURB], rng: ref HmacDrbgContext
+    msg: seq[byte], surbs: seq[SURB]
 ): Result[seq[byte], string] =
   if surbs.len > high(int8):
     return err("too many SURBs")

--- a/mix/sphinx.nim
+++ b/mix/sphinx.nim
@@ -355,7 +355,8 @@ proc processSphinxPacket*(
       else:
         return err("delta_prime should be all zeros")
     elif B[0 .. (t * k) - 1] == newSeq[byte](t * k):
-      # TODO: extract I
+      let I = B[(t * k) .. (((t + 1) * k) - 1)]
+      # TODO: return I
       return ok((hop, B[addrSize .. ((t * k) - 1)], delta_prime, Reply))
   else:
     # Extract routing information from B

--- a/mix/sphinx.nim
+++ b/mix/sphinx.nim
@@ -112,13 +112,17 @@ proc generateRandomDelay(): seq[byte] =
   return toseq(delayBytes)
 ]#
 
-const paddingLength = (((t + 1) * (r - L)) + 2) * k
+const paddingLength = (((t + 1) * (r - L)) + 1) * k
 
 # Function to compute:
 # Beta: The nested encrypted routing information. It encodes the next hop address, the forwarding delay, integrity check Gamma for the next hop, and the Beta for subsequent hops.
 # Gamma: A message authentication code computed over Beta using the session key derived from Alpha. It ensures header integrity at each hop.
 proc computeBetaGamma(
-    s: seq[seq[byte]], hop: openArray[Hop], delay: openArray[seq[byte]], destHop: Hop
+    s: seq[seq[byte]],
+    hop: openArray[Hop],
+    delay: openArray[seq[byte]],
+    destHop: Hop,
+    id: I,
 ): Result[(seq[byte], seq[byte]), string] = # TODO: name tuples
   let sLen = s.len
   var
@@ -139,7 +143,7 @@ proc computeBetaGamma(
     # Compute Beta and Gamma
     if i == sLen - 1:
       let destBytes = ?destHop.serialize()
-      let destPadding = destBytes & delay[i] & newSeq[byte](paddingLength)
+      let destPadding = destBytes & delay[i] & @id & newSeq[byte](paddingLength)
 
       let aes = aes_ctr(beta_aes_key, beta_iv, destPadding).valueOr:
         return err("Error in aes: " & error)
@@ -186,22 +190,34 @@ proc computeDelta(s: seq[seq[byte]], msg: Message): Result[seq[byte], string] =
 proc createSURB*(
     publicKeys: openArray[FieldElement],
     delay: openArray[seq[byte]],
-    hop: openArray[Hop],
+    hops: openArray[Hop],
     destHop: Hop,
-): Result[(Hop, Header, seq[seq[byte]], seq[byte]), string] =
+    id: I,
+): Result[SURB, string] =
+  if hops.len != 0:
+    assert hops[hops.len - 1] == destHop,
+      "Last element from hops sequence should match the destHop"
+
   # Compute alpha and shared secrets
   let (alpha_0, s) = computeAlpha(publicKeys).valueOr:
     return err("Error in alpha generation: " & error)
 
   # Compute beta and gamma
-  let (beta_0, gamma_0) = computeBetaGamma(s, hop, delay, destHop).valueOr:
+  let (beta_0, gamma_0) = computeBetaGamma(s, hops, delay, destHop, id).valueOr:
     return err("Error in beta and gamma generation: " & error)
 
   # Generate key
   var key = newSeqUninitialized[byte](k)
   discard randomBytes(key)
 
-  return ok((hop[0], Header.init(alpha_0, beta_0, gamma_0), s, key))
+  return ok(
+    SURB(
+      hop: hops[0],
+      header: Header.init(alpha_0, beta_0, gamma_0),
+      secret: Opt.some(s),
+      key: key,
+    )
+  )
 
 proc useSURB*(header: Header, key: seq[byte], msg: Message): Result[seq[byte], string] =
   # Derive AES key and IV
@@ -262,7 +278,7 @@ proc wrapInSphinxPacket*(
     return err("Error in alpha generation: " & error)
 
   # Compute beta and gamma
-  let (beta_0, gamma_0) = computeBetaGamma(s, hop, delay, destHop).valueOr:
+  let (beta_0, gamma_0) = computeBetaGamma(s, hop, delay, destHop, default(I)).valueOr:
     return err("Error in beta and gamma generation: " & error)
 
   # Compute delta

--- a/mix/sphinx.nim
+++ b/mix/sphinx.nim
@@ -191,19 +191,17 @@ proc createSURB*(
     publicKeys: openArray[FieldElement],
     delay: openArray[seq[byte]],
     hops: openArray[Hop],
-    destHop: Hop,
     id: I,
 ): Result[SURB, string] =
-  if hops.len != 0:
-    assert hops[hops.len - 1] == destHop,
-      "Last element from hops sequence should match the destHop"
+  if id == default(I):
+    return err("id should be initialized")
 
   # Compute alpha and shared secrets
   let (alpha_0, s) = computeAlpha(publicKeys).valueOr:
     return err("Error in alpha generation: " & error)
 
   # Compute beta and gamma
-  let (beta_0, gamma_0) = computeBetaGamma(s, hops, delay, destHop, id).valueOr:
+  let (beta_0, gamma_0) = computeBetaGamma(s, hops, delay, Hop(), id).valueOr:
     return err("Error in beta and gamma generation: " & error)
 
   # Generate key
@@ -343,17 +341,21 @@ proc processSphinxPacket*(
   # Check if B has the required prefix for the original message
   zeroPadding = newSeq[byte](paddingLength)
 
-  if B[(t * k) .. (t * k) + paddingLength - 1] == zeroPadding:
+  if B[((t + 1) * k) .. ((t + 1) * k) + paddingLength - 1] == zeroPadding:
     let hop = Hop.deserialize(B[0 .. addrSize - 1]).valueOr:
       return err(error)
 
-    if delta_prime[0 .. (k - 1)] == newSeq[byte](k):
-      let msg = Message.deserialize(delta_prime).valueOr:
-        return err("Message deserialization error: " & error)
-      let content = msg.getContent()
-      return
-        ok((hop, B[addrSize .. ((t * k) - 1)], content[0 .. messageSize - 1], Exit))
-    else:
+    if B[addrSize .. ((t + 1) * k) - 1] == newSeq[byte](k + 2):
+      if delta_prime[0 .. (k - 1)] == newSeq[byte](k):
+        let msg = Message.deserialize(delta_prime).valueOr:
+          return err("Message deserialization error: " & error)
+        let content = msg.getContent()
+        return
+          ok((hop, B[addrSize .. ((t * k) - 1)], content[0 .. messageSize - 1], Exit))
+      else:
+        return err("delta_prime should be all zeros")
+    elif B[0 .. (t * k) - 1] == newSeq[byte](t * k):
+      # TODO: extract I
       return ok((hop, B[addrSize .. ((t * k) - 1)], delta_prime, Reply))
   else:
     # Extract routing information from B

--- a/tests/test_sphinx.nim
+++ b/tests/test_sphinx.nim
@@ -306,12 +306,12 @@ suite "Sphinx Tests":
   test "create_and_use_surb":
     let (message, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
 
-    let surbRes = createSURB(publicKeys, delay, hops, dest)
+    let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
     if surbRes.isErr:
       error "Create SURB error", err = surbRes.error
-    let (hop, header, s, key) = surbRes.get()
+    let surb = surbRes.get()
 
-    let packetBytesRes = useSURB(header, key, message)
+    let packetBytesRes = useSURB(surb.header, surb.key, message)
     if packetBytesRes.isErr:
       error "Use SURB error", err = packetBytesRes.error
     let packetBytes = packetBytesRes.get()
@@ -379,7 +379,7 @@ suite "Sphinx Tests":
       error "Processing status should be Reply"
       fail()
 
-    let msgRes = processReply(key, s, processedPacket3)
+    let msgRes = processReply(surb.key, surb.secret.get(), processedPacket3)
     if msgRes.isErr:
       error "Reply processing failed", err = msgRes.error
     let msg = msgRes.get()
@@ -391,7 +391,7 @@ suite "Sphinx Tests":
   test "create_surb_empty_public_keys":
     let (message, _, _, delay, _, dest) = createDummyData()
 
-    let surbRes = createSURB(@[], delay, @[], dest)
+    let surbRes = createSURB(@[], delay, @[], dest, default(I))
     if surbRes.isOk:
       error "Expected create SURB error when public keys are empty, but got success"
       fail()
@@ -399,12 +399,12 @@ suite "Sphinx Tests":
   test "surb_sphinx_process_invalid_mac":
     let (message, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
 
-    let surbRes = createSURB(publicKeys, delay, hops, dest)
+    let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
     if surbRes.isErr:
       error "Create SURB error", err = surbRes.error
-    let (hop, header, s, key) = surbRes.get()
+    let surb = surbRes.get()
 
-    let packetRes = useSURB(header, key, message)
+    let packetRes = useSURB(surb.header, surb.key, message)
     if packetRes.isErr:
       error "Use SURB error", err = packetRes.error
     let packet = packetRes.get()
@@ -437,12 +437,12 @@ suite "Sphinx Tests":
   test "surb_sphinx_process_duplicate_tag":
     let (message, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
 
-    let surbRes = createSURB(publicKeys, delay, hops, dest)
+    let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
     if surbRes.isErr:
       error "Create SURB error", err = surbRes.error
-    let (hop, header, s, key) = surbRes.get()
+    let surb = surbRes.get()
 
-    let packetBytesRes = useSURB(header, key, message)
+    let packetBytesRes = useSURB(surb.header, surb.key, message)
     if packetBytesRes.isErr:
       error "Use SURB error", err = packetBytesRes.error
     let packetBytes = packetBytesRes.get()
@@ -489,12 +489,12 @@ suite "Sphinx Tests":
         message[i] = byte(rand(256))
       let paddedMessage = padMessage(message, messageSize)
 
-      let surbRes = createSURB(publicKeys, delay, hops, dest)
+      let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
       if surbRes.isErr:
         error "Create SURB error", err = surbRes.error
-      let (hop, header, s, key) = surbRes.get()
+      let surb = surbRes.get()
 
-      let packetBytesRes = useSURB(header, key, Message.init(paddedMessage))
+      let packetBytesRes = useSURB(surb.header, surb.key, Message.init(paddedMessage))
       if packetBytesRes.isErr:
         error "Use SURB error", err = packetBytesRes.error
       let packetBytes = packetBytesRes.get()
@@ -564,7 +564,7 @@ suite "Sphinx Tests":
         error "Processing status should be Reply"
         fail()
 
-      let msgRes = processReply(key, s, processedPacket3)
+      let msgRes = processReply(surb.key, surb.secret.get(), processedPacket3)
       if msgRes.isErr:
         error "Reply processing failed", err = msgRes.error
       let msg = msgRes.get()

--- a/tests/test_sphinx.nim
+++ b/tests/test_sphinx.nim
@@ -2,6 +2,7 @@
 
 import chronicles, random, results, unittest
 import ../mix/[config, curve25519, serialization, sphinx, tag_manager]
+import bearssl/rand
 
 # Helper function to pad/truncate message
 proc padMessage(message: openArray[byte], size: int): seq[byte] =
@@ -50,6 +51,14 @@ proc createDummyData(): (
     message = Message.init(newSeq[byte](messageSize))
     dest = Hop.init(newSeq[byte](addrSize))
   return (message, privateKeys, publicKeys, delay, hops, dest)
+
+proc randomI(): I =
+  let rng = HmacDrbgContext.new()
+  if rng.isNil:
+    doAssert false, "Failed to creat HmacDrbgContext with system randomness"
+  var id: I
+  hmacDrbgGenerate(rng[], id)
+  return id
 
 # Unit tests for sphinx.nim
 suite "Sphinx Tests":
@@ -304,9 +313,9 @@ suite "Sphinx Tests":
         fail()
 
   test "create_and_use_surb":
-    let (message, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
+    let (message, privateKeys, publicKeys, delay, hops, _) = createDummyData()
 
-    let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
+    let surbRes = createSURB(publicKeys, delay, hops, randomI())
     if surbRes.isErr:
       error "Create SURB error", err = surbRes.error
     let surb = surbRes.get()
@@ -389,17 +398,17 @@ suite "Sphinx Tests":
       fail()
 
   test "create_surb_empty_public_keys":
-    let (message, _, _, delay, _, dest) = createDummyData()
+    let (message, _, _, delay, _, _) = createDummyData()
 
-    let surbRes = createSURB(@[], delay, @[], dest, default(I))
+    let surbRes = createSURB(@[], delay, @[], randomI())
     if surbRes.isOk:
       error "Expected create SURB error when public keys are empty, but got success"
       fail()
 
   test "surb_sphinx_process_invalid_mac":
-    let (message, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
+    let (message, privateKeys, publicKeys, delay, hops, _) = createDummyData()
 
-    let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
+    let surbRes = createSURB(publicKeys, delay, hops, randomI())
     if surbRes.isErr:
       error "Create SURB error", err = surbRes.error
     let surb = surbRes.get()
@@ -435,9 +444,9 @@ suite "Sphinx Tests":
       fail()
 
   test "surb_sphinx_process_duplicate_tag":
-    let (message, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
+    let (message, privateKeys, publicKeys, delay, hops, _) = createDummyData()
 
-    let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
+    let surbRes = createSURB(publicKeys, delay, hops, randomI())
     if surbRes.isErr:
       error "Create SURB error", err = surbRes.error
     let surb = surbRes.get()
@@ -482,14 +491,14 @@ suite "Sphinx Tests":
   test "create_and_use_surb_message_sizes":
     let messageSizes = @[32, 64, 128, 256, 512]
     for size in messageSizes:
-      let (_, privateKeys, publicKeys, delay, hops, dest) = createDummyData()
+      let (_, privateKeys, publicKeys, delay, hops, _) = createDummyData()
       var message = newSeq[byte](size)
       randomize()
       for i in 0 ..< size:
         message[i] = byte(rand(256))
       let paddedMessage = padMessage(message, messageSize)
 
-      let surbRes = createSURB(publicKeys, delay, hops, dest, default(I))
+      let surbRes = createSURB(publicKeys, delay, hops, randomI())
       if surbRes.isErr:
         error "Create SURB error", err = surbRes.error
       let surb = surbRes.get()


### PR DESCRIPTION
Only the sender-Side flow for Entry, and Exit-Side flow 

## Sender-Side Flow (Entry)

- [x] The origin protocol sends (message, codec, Opt[destination], num_SURBs) to the entry layer.
- [x] If no destination is specified, the entry layer sets destination := 0...0 (all zero bytes).
- [x] The entry layer forwards (message, codec, destination, num_SURBs) to the local Mix Protocol instance.
- [x] For each SURB, the Mix instance:
  - [x] Selects L-1 random mix nodes and delays.
  - [x] Sets the L-th node to the sender itself.
  - [x] Calls createSURB(publicKeys, delay, hops, dest) → returns (first_hop, header, k, s).
- [x] The rest of the Sphinx construction follows anonymizeLocalProtocolSend.
- [x] The Mix instance:
  - [x] Adds (first_hop, header, k) for each SURB and the total number of SURBs to the payload.
  - [x] Chooses a random 16-byte ID I ∈ {0,1}^κ and stores (k, s) in a local table indexed by I.
- [X] In the final hop layer (when i == L-1), the β field is set to:
      β L − 1 := AES ( key, iv, destination | delay | I | 0-padding ) | filler
      where 0-padding fills out the rest of the fixed-size β field.

## Exit-Side Flow (Sending Reply)
- [x] When the exit receives a forward message with SURBs, it:
  - [x] Extracts (num_SURBs, list of (first_hop, header, k)).
  - [x] **(?)** Stores them in a table indexed by the stream ID opened to the destination.
- [x]  When the destination responds on the same stream:
  - [x] **(?)** The Mix instance retrieves the stored SURBs using the stream ID.
  - [x] Uses useSURB(header, k, msg) to wrap the response in a Sphinx packet.
  - [x] Sends it to the first hop on the return path.
Note: The sender is expected to include 3–4 SURBs for reliability. The recipient simultaneously sends response in all the paths.
